### PR TITLE
Replace Browser with Browser2 and BookmarkProvider

### DIFF
--- a/target/product/core.mk
+++ b/target/product/core.mk
@@ -22,7 +22,8 @@
 
 PRODUCT_PACKAGES += \
     BasicDreams \
-    Browser \
+    BookmarkProvider \
+    Browser2 \
     Calculator \
     Calendar \
     CalendarProvider \


### PR DESCRIPTION
Browser is going away. Browser2 is a tiny, WebView-based browser for
testing purposes. BookmarkProvider will take over the
"com.android.browser;browser" authorities and return empty Cursors for
all queries. See packages/apps/Browser2/README for how to obtain a
regular browser.

BUG:24744434
Change-Id: I8af605ec65a1185923598ba553a98e3fd9b887db
(cherry picked from commit 4271a9b3ed5ffa40e4ef24801cab5690fe5ca56f)
